### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ ! matrix.stable }}
     strategy:
       matrix:
@@ -15,12 +15,19 @@ jobs:
         os:
           - fedora:latest
           - quay.io/centos/centos:stream8
-          - quay.io/centos/centos:stream9
           - debian:testing
           - debian:latest
           - ubuntu:rolling
+          - ubuntu:jammy
+          - ubuntu:focal
         stable:: [true]
         include:
+          - compiler: gcc
+            os: quay.io/centos/centos:stream9
+            stable: true
+          - compiler: gcc
+            os: centos:7
+            stable: true
           - compiler: gcc
             os: fedora:rawhide
             stable: false
@@ -34,8 +41,8 @@ jobs:
             os: ubuntu:devel
             stable: false
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+      
       - name: Show OS information
         run: |
           cat /etc/os-release 2>/dev/null || echo /etc/os-release not available

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,7 @@ jobs:
           - clang
         os:
           - fedora:latest
-          - centos:7
           - quay.io/centos/centos:stream8
-          - quay.io/centos/centos:stream9
           - debian:testing
           - debian:latest
           - ubuntu:rolling
@@ -24,6 +22,12 @@ jobs:
           - ubuntu:focal
         stable:: [true]
         include:
+          - compiler: gcc
+            os: quay.io/centos/centos:stream9
+            stable: true
+          - compiler: gcc
+            os: centos:7
+            stable: true
           - compiler: gcc
             os: fedora:rawhide
             stable: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
           - clang
         os:
           - fedora:latest
+          - centos:7
           - quay.io/centos/centos:stream8
+          - quay.io/centos/centos:stream9
           - debian:testing
           - debian:latest
           - ubuntu:rolling
@@ -22,12 +24,6 @@ jobs:
           - ubuntu:focal
         stable:: [true]
         include:
-          - compiler: gcc
-            os: quay.io/centos/centos:stream9
-            stable: true
-          - compiler: gcc
-            os: centos:7
-            stable: true
           - compiler: gcc
             os: fedora:rawhide
             stable: false

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -22,7 +22,7 @@ debian:*|ubuntu:*)
         sleep 5
     done
     ;;
-
+--allowerasing
 fedora:*)
     echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
     dnf -y clean all
@@ -36,7 +36,7 @@ fedora:*)
     yum install -y yum-utils epel-release
     yum-config-manager -y --enable crb \
         || yum-config-manager -y --enable powertools || :
-    yum -y --allowerasing install ${COMMON}
+    yum -y install ${COMMON}
     yum-builddep -y jose
     ;;
 

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -34,8 +34,8 @@ fedora:*)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils epel-release
-    yum-config-manager -y --set-enabled crb \
-        || yum-config-manager -y --set-enabled powertools || :
+    yum-config-manager -y --enable crb \
+        || yum-config-manager -y --enable powertools || :
     yum -y --allowerasing install ${COMMON}
     yum-builddep -y jose
     ;;

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -39,5 +39,16 @@ fedora:*)
     yum -y --allowerasing install ${COMMON}
     yum-builddep -y jose
     ;;
+
+*centos:stream*)
+    dnf -y clean all
+    dnf -y --setopt=deltarpm=0 update
+    dnf install -y dnf-plugins-core epel-release
+    dnf config-manager -y --set-enabled powertools \
+        || dnf config-manager -y --set-enabled crb || :
+    dnf -y install ${COMMON}
+    dnf builddep -y jose
+    ;;
+
 esac
 # vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -34,6 +34,8 @@ fedora:*)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils epel-release
+    yum-config-manager -y --set-enabled crb \
+        || yum-config-manager -y --set-enabled powertools || :
     yum -y --allowerasing install ${COMMON}
     yum-builddep -y jose
     ;;

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -34,8 +34,6 @@ fedora:*)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils epel-release
-    yum config-manager -y --set-enabled crb \
-        || yum config-manager -y --set-enabled powertools || :
     yum -y --allowerasing install ${COMMON}
     yum-builddep -y jose
     ;;

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -46,7 +46,7 @@ fedora:*)
     dnf install -y dnf-plugins-core epel-release
     dnf config-manager -y --set-enabled powertools \
         || dnf config-manager -y --set-enabled crb || :
-    dnf -y install ${COMMON}
+    dnf -y install --allowerasing ${COMMON}
     dnf builddep -y jose
     ;;
 

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -22,7 +22,7 @@ debian:*|ubuntu:*)
         sleep 5
     done
     ;;
---allowerasing
+
 fedora:*)
     echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
     dnf -y clean all


### PR DESCRIPTION
This updates github actions to:
- Include current OS versions
- Update actions/checkout to version 3 in advance of the imminent NodeJS deprecation
- Add dependency installation for CentOS Stream versions

In my initial pass, there were failures for Ubuntu:bionic and, for clang on CentOS 7 and CentOS Stream 9.  Rather than spend a lot of time trying to resolve the failures I simply removed the clang attempts for CentOS7 and Stream 9.  It's probably some dependency issue if someone wants to chase it.  I simply removed Ubuntu:bionic since it's EOL at the end of the month anyway.
